### PR TITLE
Fix breaking changes from recent Pymatgen v2022.0. release

### DIFF
--- a/CrySPY/gen_struc/EA/crossover.py
+++ b/CrySPY/gen_struc/EA/crossover.py
@@ -6,7 +6,7 @@ from collections import Counter
 import sys
 
 import numpy as np
-from pymatgen import Structure, Lattice
+from pymatgen.core import Structure, Lattice
 
 from ..struc_util import origin_shift, sort_by_atype, check_distance
 

--- a/CrySPY/gen_struc/EA/strain.py
+++ b/CrySPY/gen_struc/EA/strain.py
@@ -4,7 +4,7 @@ Strain class
 import sys
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from ..struc_util import sort_by_atype, check_distance
 

--- a/CrySPY/gen_struc/random/gen_pyxtal.py
+++ b/CrySPY/gen_struc/random/gen_pyxtal.py
@@ -9,7 +9,9 @@ import random
 import sys
 
 import numpy as np
-from pymatgen import DummySpecie, Structure, Molecule
+from pymatgen.core import Structure, Molecule
+from pymatgen.core.periodic_table import DummySpecie
+
 from pyxtal import pyxtal
 from pyxtal.database.collection import Collection
 

--- a/CrySPY/gen_struc/random/random_generation.py
+++ b/CrySPY/gen_struc/random/random_generation.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from ..struc_util import check_distance
 from ..struc_util import out_poscar

--- a/CrySPY/gen_struc/struc_util.py
+++ b/CrySPY/gen_struc/struc_util.py
@@ -5,7 +5,7 @@ Utility for structures
 import os
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.cif import CifWriter
 
 

--- a/CrySPY/interface/LAMMPS/structure.py
+++ b/CrySPY/interface/LAMMPS/structure.py
@@ -5,7 +5,7 @@ Structure file for LAMMPS
 import itertools
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from ...IO import read_input as rin
 

--- a/CrySPY/interface/OMX/structure.py
+++ b/CrySPY/interface/OMX/structure.py
@@ -4,7 +4,7 @@ written by H. Sawahata 2020/03/09
 info at hikaruri.jp
 '''
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.core.units import Length
 
 from ...IO import read_input as rin

--- a/CrySPY/interface/QE/structure.py
+++ b/CrySPY/interface/QE/structure.py
@@ -2,7 +2,7 @@
 Structure file for Quantum ESPRESSO
 '''
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.core.units import Length
 
 from ...IO import read_input as rin

--- a/CrySPY/interface/VASP/collect_vasp.py
+++ b/CrySPY/interface/VASP/collect_vasp.py
@@ -6,7 +6,7 @@ import os
 import xml.etree.ElementTree as ET
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 
 from ... import utility
 from ...IO import pkl_data

--- a/CrySPY/interface/VASP/ctrl_job_vasp.py
+++ b/CrySPY/interface/VASP/ctrl_job_vasp.py
@@ -5,7 +5,7 @@ Control jobs in VASP
 import os
 import shutil
 
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp.sets import MITRelaxSet
 
 from ...IO.out_results import out_kpts

--- a/CrySPY/interface/soiap/structure.py
+++ b/CrySPY/interface/soiap/structure.py
@@ -5,7 +5,7 @@ Structure files in soiap
 import itertools
 
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from ... import utility


### PR DESCRIPTION
Pymatgen root imports have been removed from v2022.0.0.

All root imports from core package have been changed to their canonical import `pymatgen.core`
