### PR TITLE
concat method is used due to the deprecated frame.append method

### DIFF
--- a/CrySPY/EA/ea_next_gen.py
+++ b/CrySPY/EA/ea_next_gen.py
@@ -76,7 +76,7 @@ def next_gen(stat, init_struc_data, opt_struc_data, rslt_data, ea_id_data):
                           rin.n_strain, rin.n_rand, rin.n_elite,
                           rin.crs_lat, rin.slct_func],
                          index=ea_info.columns)
-    ea_info = ea_info.append(tmp_info, ignore_index=True)
+    ea_info = pd.concat([ea_info, pd.DataFrame(tmp_info).T], axis=0, ignore_index=True)
     # ------ out ea_info
     out_results.out_ea_info(ea_info)
 
@@ -85,19 +85,19 @@ def next_gen(stat, init_struc_data, opt_struc_data, rslt_data, ea_id_data):
     for cid in range(rin.tot_struc, rin.tot_struc + rin.n_pop - rin.n_rand):
         tmp_origin = pd.Series([gen, cid, eagen.operation[cid],
                                 eagen.parents[cid]], index=ea_origin.columns)
-        ea_origin = ea_origin.append(tmp_origin, ignore_index=True)
+        ea_info = pd.concat([ea_info, pd.DataFrame(tmp_info).T], axis=0, ignore_index=True)
     # ------ random part
     for cid in range(rin.tot_struc + rin.n_pop - rin.n_rand,
                      rin.tot_struc + rin.n_pop):
         tmp_origin = pd.Series([gen, cid, 'random', None],
                                index=ea_origin.columns)
-        ea_origin = ea_origin.append(tmp_origin, ignore_index=True)
+        ea_info = pd.concat([ea_info, pd.DataFrame(tmp_info).T], axis=0, ignore_index=True)
     # ------ elite part
     if rin.n_elite > 0:
         for cid in se.ranking_dedupe:
             tmp_origin = pd.Series([gen, cid, 'elite', 'elite'],
                                    index=ea_origin.columns)
-            ea_origin = ea_origin.append(tmp_origin, ignore_index=True)
+            ea_origin = pd.concat([ea_origin, pd.DataFrame(tmp_origin).T], axis=0, ignore_index=True)
     # ------ out ea_origin
     out_results.out_ea_origin(ea_origin)
 


### PR DESCRIPTION
Hi, Yamashita-san

I noticed the warning "FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version." these days when I used the latest two versions of CrySPY to generate the structures in the next generation. 
I employed "concat" method instead of the "append" method for your consideration. A demo example is shown below to compare the two methods.

Best wishes
Yuewen Fang

## The "append" method in CrySPY

```python
import pickle 
import pandas as pd

def load_ea_data():
    with open('./EA_data.pkl', 'rb') as f:
        ea_data = pickle.load(f)
    return ea_data

elite_struc, elite_fitness, ea_info, ea_origin = load_ea_data()
print(ea_info)
tmp_info = pd.Series([9999, 50, 9999, 9999, 9999, 9999, 9999,'equal', 'TNM'], index=ea_info.columns)
ea_info = ea_info.append(tmp_info, ignore_index=True)
print(ea_info)
```
The output is
```
Gen Population Crossover Permutation Strain Random Elite crs_lat slct_func
0   1         50         0           0      0     50     0   equal       TNM
1   2         50        20           5     10     15     5   equal       TNM
2   3         50        25           5     10     10     5   equal       TNM
3   4         50        25           5     10     10     5   equal       TNM
4   5         50        25           5     10     10     5   equal       TNM
5   6         50        25           5     10     10     5   equal       TNM
6   7         50        25           5     10     10     5   equal       TNM
    Gen Population Crossover Permutation Strain Random Elite crs_lat slct_func
0     1         50         0           0      0     50     0   equal       TNM
1     2         50        20           5     10     15     5   equal       TNM
2     3         50        25           5     10     10     5   equal       TNM
3     4         50        25           5     10     10     5   equal       TNM
4     5         50        25           5     10     10     5   equal       TNM
5     6         50        25           5     10     10     5   equal       TNM
6     7         50        25           5     10     10     5   equal       TNM
7  9999         50      9999        9999   9999   9999  9999   equal       TNM
/tmp/ipykernel_55523/2456999282.py:12: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  ea_info = ea_info.append(tmp_info, ignore_index=True)
```

## The "contact" method in CrySPY
```python
import pickle 
import pandas as pd

def load_ea_data():
    with open('./EA_data.pkl', 'rb') as f:
        ea_data = pickle.load(f)
    return ea_data

elite_struc, elite_fitness, ea_info, ea_origin = load_ea_data()
print(ea_info)

tmp_info = pd.Series([9999, 50, 9999, 9999, 9999, 9999, 9999,'equal', 'TNM'], index=ea_info.columns)
ea_info = pd.concat([ea_info, pd.DataFrame(tmp_info).T], axis=0, ignore_index=True)
print(ea_info)
```
The output is
 ```
Gen Population Crossover Permutation Strain Random Elite crs_lat slct_func
0   1         50         0           0      0     50     0   equal       TNM
1   2         50        20           5     10     15     5   equal       TNM
2   3         50        25           5     10     10     5   equal       TNM
3   4         50        25           5     10     10     5   equal       TNM
4   5         50        25           5     10     10     5   equal       TNM
5   6         50        25           5     10     10     5   equal       TNM
6   7         50        25           5     10     10     5   equal       TNM
    Gen Population Crossover Permutation Strain Random Elite crs_lat slct_func
0     1         50         0           0      0     50     0   equal       TNM
1     2         50        20           5     10     15     5   equal       TNM
2     3         50        25           5     10     10     5   equal       TNM
3     4         50        25           5     10     10     5   equal       TNM
4     5         50        25           5     10     10     5   equal       TNM
5     6         50        25           5     10     10     5   equal       TNM
6     7         50        25           5     10     10     5   equal       TNM
7  9999         50      9999        9999   9999   9999  9999   equal       TNM
​
```